### PR TITLE
Podman fails to parse port ranges in a Dockerfile

### DIFF
--- a/samba-ad-dc/Dockerfile
+++ b/samba-ad-dc/Dockerfile
@@ -38,7 +38,8 @@ EXPOSE 464/tcp
 EXPOSE 636/tcp
 EXPOSE 3268/tcp
 EXPOSE 3269/tcp
-EXPOSE 49152-65535/tcp
+# Ports 49152-65535/tcp are required, but podman can't parse a port range in the Dockerfile
+EXPOSE 49152/tcp
 
 # The container must be run with `--cap-add SYS_ADMIN` otherwise acls will fail
 


### PR DESCRIPTION
It seems some podman versions fail to parse the Dockerfile if an EXPOSE is set to a port range. These are just hints anyway, so disable the port range.